### PR TITLE
Qemu v8.0.0 support

### DIFF
--- a/pycparser/c_generator.py
+++ b/pycparser/c_generator.py
@@ -394,7 +394,11 @@ class CGenerator(object):
                     nstr += modifiers[i].prefix
                     if (i != 0 and isinstance(modifiers[i - 1], c_ast.PtrDecl)):
                         nstr = '(' + nstr + ')'
-                    nstr += '(' + self.visit(modifier.args) + ')'
+                    args = modifier.args
+                    if args:
+                        nstr += '(' + self.visit(args) + ')'
+                    else:
+                        nstr += '()'
                 elif isinstance(modifier, c_ast.PtrDecl):
                     if modifier.quals:
                         nstr = modifiers[i].prefix + \

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -723,7 +723,11 @@ class I3SProcessing(object):
 
         old_local = copy(cs.tcg_tmp_local_list_hold)
 
-        given_args = len(node.args.exprs)
+        args = node.args
+        if args:
+            given_args = len(args.exprs)
+        else:
+            given_args = 0
 
         if args_count != given_args:
             raise TypeError(
@@ -732,7 +736,7 @@ class I3SProcessing(object):
                 )
             )
 
-        zip_arg_with_type = zip(node.args.exprs, node.args_type)
+        zip_arg_with_type = zip(args.exprs if args else [], node.args_type)
         has_tcg_arg = False
 
         if debug:

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -2375,14 +2375,16 @@ def determine_var_type(node, ns = {}, func_params = {}):
         func_name = node.decl.type.type.declname
         func_params[func_name] = []
         body_ns = ns.copy()
-        for p in node.decl.type.args.params:
-            while not (
-                    isinstance(p, c_ast.TypeDecl)
-                and isinstance(p.type, c_ast.IdentifierType)
-            ):
-                p = p.type
-            body_ns[p.declname] = [p.type, False]
-            func_params[func_name].append(p.type.names)
+        args = node.decl.type.args
+        if args:
+            for p in args.params:
+                while not (
+                        isinstance(p, c_ast.TypeDecl)
+                    and isinstance(p.type, c_ast.IdentifierType)
+                ):
+                    p = p.type
+                body_ns[p.declname] = [p.type, False]
+                func_params[func_name].append(p.type.names)
 
         determine_var_type(node.body, body_ns)
 

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -415,7 +415,7 @@ class CompoundState(object):
 
     def convert_var_to_tcg(self, val, res_type):
         suffix = get_tcg_suffix(res_type)
-        tmp = self.get_unoccupied_tmp_tcg(suffix)
+        tmp = self.get_unoccupied_tmp_tcg(res_type)
 
         if isinstance(val, c_ast.Paren):
             val = val.expr

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -757,7 +757,7 @@ class I3SProcessing(object):
                     res = cs.cast(
                         (p_arg, None, None),
                         (None, at, None),
-                        True and self.locals_enabled
+                        self.locals_enabled
                     )
                     for e in cs.subast:
                         set_node_prefix(e, cs.indent)
@@ -765,7 +765,7 @@ class I3SProcessing(object):
                 for tmp_name, __ in cs.tcg_tmp_list:
                     if tmp_name == res.name:
                         local_var = cs.get_unoccupied_tmp_tcg(at,
-                            True and self.locals_enabled
+                            self.locals_enabled
                         )
                         res.prefix = ' '
                         suffix = get_tcg_suffix(at)
@@ -1293,7 +1293,7 @@ class I3SProcessing(object):
         for tmp_name, __ in cs.tcg_tmp_list:
             if cond.name == tmp_name:
                 local_var = cs.get_unoccupied_tmp_tcg(cond_type,
-                    True and self.locals_enabled
+                    self.locals_enabled
                 )
                 cond.prefix = ' '
                 self.cs.subast.append(c_ast.FuncCall(

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -264,6 +264,9 @@ def change_declname(node, new_name):
 
 
 class CompoundState(object):
+
+    trunc_func_prefix = "tcg_gen_trunc"
+
     def __init__(self, prev_state = None, temp_free_needed = True):
 
         self.vars = set()
@@ -461,7 +464,7 @@ class CompoundState(object):
                 + ('' if 'signed' in dest_type else 'u') \
                 + src_suffix + dest_suffix
         else:
-            func_name = 'tcg_gen_trunc' + src_suffix + dest_suffix
+            func_name = self.trunc_func_prefix + src_suffix + dest_suffix
 
         set_node_prefix(src, ' ')
         if dest is not None:
@@ -2408,7 +2411,11 @@ def convert_i3s_to_c(ast,
     debug = False,
     locals_enabled = True,
     temp_free_needed = True,
+    trunc_func_prefix = None,
 ):
+    if trunc_func_prefix is not None:
+        CompoundState.trunc_func_prefix = trunc_func_prefix
+
     determine_var_type(ast)
     i3s_class = I3SProcessing(
         locals_enabled = locals_enabled,

--- a/pycparser/i3s_processing.py
+++ b/pycparser/i3s_processing.py
@@ -265,7 +265,7 @@ def change_declname(node, new_name):
 
 class CompoundState(object):
 
-    trunc_func_prefix = "tcg_gen_trunc"
+    replaced_funcs = {}
 
     def __init__(self, prev_state = None, temp_free_needed = True):
 
@@ -464,7 +464,9 @@ class CompoundState(object):
                 + ('' if 'signed' in dest_type else 'u') \
                 + src_suffix + dest_suffix
         else:
-            func_name = self.trunc_func_prefix + src_suffix + dest_suffix
+            func_name = 'tcg_gen_trunc' + src_suffix + dest_suffix
+
+        func_name = self.replaced_funcs.get(func_name, func_name)
 
         set_node_prefix(src, ' ')
         if dest is not None:
@@ -2417,10 +2419,10 @@ def convert_i3s_to_c(ast,
     debug = False,
     locals_enabled = True,
     temp_free_needed = True,
-    trunc_func_prefix = None,
+    replaced_funcs = None,
 ):
-    if trunc_func_prefix is not None:
-        CompoundState.trunc_func_prefix = trunc_func_prefix
+    if replaced_funcs is not None:
+        CompoundState.replaced_funcs = replaced_funcs
 
     determine_var_type(ast)
     i3s_class = I3SProcessing(

--- a/tests/i3s/i3s.c
+++ b/tests/i3s/i3s.c
@@ -666,4 +666,8 @@ int func_call_test() {
     helper(a + 1, helper(a + 1, b + b));
 }
 
+int no_args_func_call_test() {
+	func_call_test();
+}
+
 #endif /* INCLUDE_I3S_C */

--- a/tests/i3s/i3s.c
+++ b/tests/i3s/i3s.c
@@ -634,7 +634,7 @@ int for_test(void) {
 
 int helper(short tcg a1, tcg a2) {}
 
-int func_call_test(void) {
+int func_call_test() {
     int a = 5;
     tcg b = 6;
 

--- a/tests/i3s/i3s_debug_reference_standards.c
+++ b/tests/i3s/i3s_debug_reference_standards.c
@@ -1464,4 +1464,8 @@ int func_call_test() {
     tcg_temp_free_i32(i3s_t2_local_i32);
 }
 
+int no_args_func_call_test() {
+	func_call_test();
+}
+
 #endif /* INCLUDE_I3S_C */

--- a/tests/i3s/i3s_debug_reference_standards.c
+++ b/tests/i3s/i3s_debug_reference_standards.c
@@ -1368,7 +1368,7 @@ int for_test(void) {
 
 int helper(TCGv_i32 a1, TCGv a2) {}
 
-int func_call_test(void) {
+int func_call_test() {
     int a = 5;
     TCGv b = tcg_temp_local_new();
     tcg_gen_movi_tl(b, 6);

--- a/tests/i3s/i3s_debug_reference_standards.c
+++ b/tests/i3s/i3s_debug_reference_standards.c
@@ -504,11 +504,10 @@ int test_expr(void) {
     tcg_gen_addi_tl(i3s_t3_tl, tcg_tl_1, 3);
     tcg_gen_divu_tl(i3s_t0_tl, i3s_t0_tl, i3s_t3_tl);
     tcg_gen_mul_tl(i3s_t3_tl, tcg_tl_1, tcg_tl_signed);
-    tcg_gen_movi_i32(i3s_t7_tl, c_var_1);
-    tcg_gen_divu_i32(i3s_t7_tl, i3s_t7_tl, tcg_i32_1);
-    TCGv i3s_t8_tl = tcg_temp_new();
-    tcg_gen_extu_i32_tl(i3s_t8_tl, i3s_t7_tl);
-    tcg_gen_divu_tl(i3s_t3_tl, i3s_t3_tl, i3s_t8_tl);
+    tcg_gen_movi_i32(i3s_t2_i32, c_var_1);
+    tcg_gen_divu_i32(i3s_t2_i32, i3s_t2_i32, tcg_i32_1);
+    tcg_gen_extu_i32_tl(i3s_t7_tl, i3s_t2_i32);
+    tcg_gen_divu_tl(i3s_t3_tl, i3s_t3_tl, i3s_t7_tl);
     tcg_gen_add_tl(tcg_tl_1, i3s_t0_tl, i3s_t3_tl);
 
     /* src: tcg_tl_1 = (long tcg)(tcg_i32_1) */
@@ -516,8 +515,9 @@ int test_expr(void) {
     tcg_gen_trunc_i64_tl(tcg_tl_1, i3s_t4_i64);
 
     /* src: tcg_tl_1 = (tcg)(tcg_i32_1 + tcg_i32_2) */
-    tcg_gen_add_i32(i3s_t2_i32, tcg_i32_1, tcg_i32_2);
-    tcg_gen_extu_i32_tl(tcg_tl_1, i3s_t2_i32);
+    TCGv_i32 i3s_t8_i32 = tcg_temp_new_i32();
+    tcg_gen_add_i32(i3s_t8_i32, tcg_i32_1, tcg_i32_2);
+    tcg_gen_extu_i32_tl(tcg_tl_1, i3s_t8_i32);
 
     /* src: tcg_tl_1 = (tcg) tcg_i64_1 */
     tcg_gen_trunc_i64_tl(tcg_tl_1, tcg_i64_1);
@@ -571,7 +571,7 @@ int test_expr(void) {
     tcg_temp_free_i32(i3s_t5_i32);
     tcg_temp_free_i32(i3s_t6_i32);
     tcg_temp_free(i3s_t7_tl);
-    tcg_temp_free(i3s_t8_tl);
+    tcg_temp_free_i32(i3s_t8_i32);
     tcg_temp_free(tcg_tl_1);
     tcg_temp_free(tcg_tl_2);
     tcg_temp_free(tcg_tl_signed);

--- a/tests/i3s/i3s_reference_standards.c
+++ b/tests/i3s/i3s_reference_standards.c
@@ -1205,4 +1205,8 @@ int func_call_test() {
     tcg_temp_free_i32(i3s_t2_local_i32);
 }
 
+int no_args_func_call_test() {
+	func_call_test();
+}
+
 #endif /* INCLUDE_I3S_C */

--- a/tests/i3s/i3s_reference_standards.c
+++ b/tests/i3s/i3s_reference_standards.c
@@ -1115,7 +1115,7 @@ int for_test(void) {
 
 int helper(TCGv_i32 a1, TCGv a2) {}
 
-int func_call_test(void) {
+int func_call_test() {
     int a = 5;
     TCGv b = tcg_temp_local_new();
     tcg_gen_movi_tl(b, 6);

--- a/tests/i3s/i3s_reference_standards.c
+++ b/tests/i3s/i3s_reference_standards.c
@@ -378,18 +378,18 @@ int test_expr(void) {
     tcg_gen_addi_tl(i3s_t3_tl, tcg_tl_1, 3);
     tcg_gen_divu_tl(i3s_t0_tl, i3s_t0_tl, i3s_t3_tl);
     tcg_gen_mul_tl(i3s_t3_tl, tcg_tl_1, tcg_tl_signed);
-    tcg_gen_movi_i32(i3s_t7_tl, c_var_1);
-    tcg_gen_divu_i32(i3s_t7_tl, i3s_t7_tl, tcg_i32_1);
-    TCGv i3s_t8_tl = tcg_temp_new();
-    tcg_gen_extu_i32_tl(i3s_t8_tl, i3s_t7_tl);
-    tcg_gen_divu_tl(i3s_t3_tl, i3s_t3_tl, i3s_t8_tl);
+    tcg_gen_movi_i32(i3s_t2_i32, c_var_1);
+    tcg_gen_divu_i32(i3s_t2_i32, i3s_t2_i32, tcg_i32_1);
+    tcg_gen_extu_i32_tl(i3s_t7_tl, i3s_t2_i32);
+    tcg_gen_divu_tl(i3s_t3_tl, i3s_t3_tl, i3s_t7_tl);
     tcg_gen_add_tl(tcg_tl_1, i3s_t0_tl, i3s_t3_tl);
 
     tcg_gen_extu_i32_i64(i3s_t4_i64, tcg_i32_1);
     tcg_gen_trunc_i64_tl(tcg_tl_1, i3s_t4_i64);
 
-    tcg_gen_add_i32(i3s_t2_i32, tcg_i32_1, tcg_i32_2);
-    tcg_gen_extu_i32_tl(tcg_tl_1, i3s_t2_i32);
+    TCGv_i32 i3s_t8_i32 = tcg_temp_new_i32();
+    tcg_gen_add_i32(i3s_t8_i32, tcg_i32_1, tcg_i32_2);
+    tcg_gen_extu_i32_tl(tcg_tl_1, i3s_t8_i32);
 
     tcg_gen_trunc_i64_tl(tcg_tl_1, tcg_i64_1);
 
@@ -434,7 +434,7 @@ int test_expr(void) {
     tcg_temp_free_i32(i3s_t5_i32);
     tcg_temp_free_i32(i3s_t6_i32);
     tcg_temp_free(i3s_t7_tl);
-    tcg_temp_free(i3s_t8_tl);
+    tcg_temp_free_i32(i3s_t8_i32);
     tcg_temp_free(tcg_tl_1);
     tcg_temp_free(tcg_tl_2);
     tcg_temp_free(tcg_tl_signed);


### PR DESCRIPTION
# v2
- remove `True and ...`
- configurable i64 to i32 truncation function prefix
- `convert_var_to_tcg` correctly calls `get_unoccupied_tmp_tcg` 
- fix empty args `()` function failure